### PR TITLE
feat: add PR comment on original code PR when other PRs are open

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,18 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install nodejs
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: 'node_modules'
-          key: ${{ hashFiles('yarn.lock') }}
+          node-version: '20'
+          cache: 'yarn'
 
       - name: Install
         run: yarn install --pure-lockfile
@@ -29,13 +24,13 @@ jobs:
       - name: Test
         run: yarn test --coverage
         env:
-          GITHUB_TOKEN: ${{ secrets.KINGKONG_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Package Data
         id: read-package
         run: |
-          echo ::set-output name=NAME::$(node -p "require('./package.json').name") | sed 's/@monom\///g'
-          echo ::set-output name=VERSION::$(node -p "require('./package.json').version")
+          echo "NAME=$(node -p "require('./package.json').name" | sed 's/@monom\///g')" >> $GITHUB_OUTPUT
+          echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,11 @@ jobs:
           node-version: '20'
           cache: 'yarn'
 
+      - name: Configure Corporate Nexus
+        run: |
+          echo "//nexus.monom.ai/repository/npm/:_auth=${{ secrets.NEXUS_AUTH }}" > .npmrc
+          echo "registry=https://nexus.monom.ai/repository/npm/" >> .npmrc
+
       - name: Install
         run: yarn install --pure-lockfile
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # github-action-close-code-pr
+
+GitHub Action to automatically close and merge the original code Pull Request when a deployment/manifest Pull Request is merged.
+
+## Features
+
+- **Automatic Merging**: When a manifest PR is merged (e.g., deployment to an environment), this action finds the original code PR and merges it automatically.
+- **Label Synchronization**: Uses labels to identify associated PRs across repositories.
+- **Status Comments**: If there are other open PRs for the same environment/labels, it will post a comment on the original code PR notifying that it's waiting for other merges before final completion.
+- **Actor Mentions**: Mentions the person who triggered the merge in the status comments for better visibility.
+
+## Inputs
+
+- `pr_number`: The PR number that triggered the action.
+- `repo_name`: The repository name where the PR is located.
+- `owner`: The owner of the repository.
+
+## Environment Variables
+
+- `GITHUB_TOKEN`: A GitHub token with permissions to read PRs, post comments, and merge PRs.
+- `GITHUB_ACTOR`: Used to mention the user in comments (provided automatically by GitHub Actions).

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,14 +1,25 @@
 jest.mock('@actions/core')
+jest.mock('../src/getLabels')
+jest.mock('../src/searchPRwithLabels')
+jest.mock('../src/searchCodePR')
+jest.mock('../src/mergePR')
+jest.mock('../src/postComment')
+
 import * as core from '@actions/core'
 import { Octokit } from "@octokit/core"
 import { main } from '../src/main'
+import { getLabels } from '../src/getLabels'
+import { searchPRwithLabels } from '../src/searchPRwithLabels'
+import { searchCodePR } from '../src/searchCodePR'
+import { postComment } from '../src/postComment'
+
+const mockedGetLabels = getLabels as jest.MockedFunction<typeof getLabels>
+const mockedSearchPRwithLabels = searchPRwithLabels as jest.MockedFunction<typeof searchPRwithLabels>
+const mockedSearchCodePR = searchCodePR as jest.MockedFunction<typeof searchCodePR>
+const mockedPostComment = postComment as jest.MockedFunction<typeof postComment>
 
 const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN
-})
-
-const nooctokit = new Octokit({
-    auth: '1234567890'
+    auth: 'test-token'
 })
 
 const input = {
@@ -17,12 +28,58 @@ const input = {
     owner: 'ThingsO2'
 }
 
-test('main', async () => {
-    const mainResult = await main(octokit, input, false)
-    expect(mainResult).toBe(core.ExitCode.Success)
-})
+describe('main with comments and actor', () => {
+    const originalEnv = process.env
 
-test('main failed', async () => {
-    const mainResult = await main(nooctokit, input, false)
-    expect(mainResult).toBe(core.ExitCode.Failure)
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env = { ...originalEnv, GITHUB_ACTOR: 'test-actor' }
+    })
+
+    afterAll(() => {
+        process.env = originalEnv
+    })
+
+    test('should post comment with actor mention when other open PRs are found', async () => {
+        mockedGetLabels.mockResolvedValue(['env-test'])
+        mockedSearchPRwithLabels.mockResolvedValue([135, 136]) // 136 is "other"
+        mockedSearchCodePR.mockResolvedValue({
+            number: 10,
+            base: {
+                repo: {
+                    name: 'original-repo',
+                    owner: { login: 'ThingsO2' }
+                }
+            }
+        } as any)
+
+        const result = await main(octokit, input, true)
+
+        expect(result).toBe(core.ExitCode.Success)
+        expect(mockedPostComment).toHaveBeenCalledWith(
+            expect.anything(),
+            10,
+            'original-repo',
+            'ThingsO2',
+            '@test-actor: Other open PRs found for these labels: 136. Nothing to merge yet.'
+        )
+    })
+
+    test('should NOT post comment when NO other open PRs are found', async () => {
+        mockedGetLabels.mockResolvedValue(['env-test'])
+        mockedSearchPRwithLabels.mockResolvedValue([135]) // Only current PR
+        mockedSearchCodePR.mockResolvedValue({
+            number: 10,
+            base: {
+                repo: {
+                    name: 'original-repo',
+                    owner: { login: 'ThingsO2' }
+                }
+            }
+        } as any)
+
+        await main(octokit, input, false) // merge=false
+
+        expect(mockedPostComment).not.toHaveBeenCalled()
+    })
 })

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'The repo owner'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'lock'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8057,9 +8057,10 @@ var getLabels_1 = __nccwpck_require__(7140);
 var searchPRwithLabels_1 = __nccwpck_require__(3595);
 var searchCodePR_1 = __nccwpck_require__(5433);
 var mergePR_1 = __nccwpck_require__(6964);
+var postComment_1 = __nccwpck_require__(5270);
 function main(octokit, input, merge) {
     return __awaiter(this, void 0, void 0, function () {
-        var prNumber, repoName, owner, labels, labelsToSearch, PRs, otherPRs, codePR, error_1;
+        var prNumber, repoName, owner, labels, labelsToSearch, PRs, otherPRs, codePR, actor, message, error_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -8070,7 +8071,7 @@ function main(octokit, input, merge) {
                     core.info("Repo Name: ".concat(repoName));
                     _a.label = 1;
                 case 1:
-                    _a.trys.push([1, 7, , 8]);
+                    _a.trys.push([1, 10, , 11]);
                     return [4 /*yield*/, (0, getLabels_1.getLabels)(octokit, prNumber, repoName, owner)];
                 case 2:
                     labels = _a.sent();
@@ -8081,14 +8082,24 @@ function main(octokit, input, merge) {
                     PRs = _a.sent();
                     otherPRs = PRs.filter(function (id) { return id !== prNumber; });
                     core.info("Found PRs: ".concat(PRs));
-                    if (!(otherPRs.length > 0)) return [3 /*break*/, 4];
-                    core.info("Other open PRs found for these labels: ".concat(otherPRs, ". Nothing to merge yet."));
-                    return [2 /*return*/, core.ExitCode.Success];
-                case 4:
-                    core.info('No other open PRs found, proceeding to merge original code PR');
                     return [4 /*yield*/, (0, searchCodePR_1.searchCodePR)(octokit, prNumber, repoName, owner)];
-                case 5:
+                case 4:
                     codePR = _a.sent();
+                    if (!(otherPRs.length > 0)) return [3 /*break*/, 8];
+                    actor = process.env.GITHUB_ACTOR;
+                    message = "".concat(actor ? "@".concat(actor, ": ") : '', "Other open PRs found for these labels: ").concat(otherPRs, ". Nothing to merge yet.");
+                    core.info(message);
+                    if (!codePR) return [3 /*break*/, 6];
+                    return [4 /*yield*/, (0, postComment_1.postComment)(octokit, codePR.number, codePR.base.repo.name, codePR.base.repo.owner.login, message)];
+                case 5:
+                    _a.sent();
+                    return [3 /*break*/, 7];
+                case 6:
+                    core.warning("Could not identify original code PR for ".concat(repoName, "#").concat(prNumber, ". Cannot post comment."));
+                    _a.label = 7;
+                case 7: return [2 /*return*/, core.ExitCode.Success];
+                case 8:
+                    core.info('No other open PRs found, proceeding to merge original code PR');
                     if (!codePR) {
                         core.warning("Could not identify original code PR for ".concat(repoName, "#").concat(prNumber, ". Verify title/body format."));
                         return [2 /*return*/, core.ExitCode.Success];
@@ -8105,12 +8116,12 @@ function main(octokit, input, merge) {
                             })];
                     }
                     return [2 /*return*/, core.ExitCode.Success];
-                case 6: return [3 /*break*/, 8];
-                case 7:
+                case 9: return [3 /*break*/, 11];
+                case 10:
                     error_1 = _a.sent();
                     core.setFailed(error_1.message);
                     return [2 /*return*/, Promise.resolve(core.ExitCode.Failure)];
-                case 8: return [2 /*return*/];
+                case 11: return [2 /*return*/];
             }
         });
     });
@@ -8216,6 +8227,109 @@ function doRequest(octokit, prNumber, repoName, owner) {
                     return [2 /*return*/, {
                             data: res,
                             status: 200,
+                            url: request,
+                            headers: {}
+                        }];
+                case 3:
+                    error_1 = _a.sent();
+                    return [2 /*return*/, new request_error_1.RequestError(error_1.message, error_1.status, {
+                            request: error_1.request,
+                            response: error_1.response,
+                        })];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}
+
+
+/***/ }),
+
+/***/ 5270:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.postComment = void 0;
+var request_error_1 = __nccwpck_require__(537);
+function postComment(octokit, prNumber, repoName, owner, body) {
+    return __awaiter(this, void 0, void 0, function () {
+        var res;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, doRequest(octokit, prNumber, repoName, owner, body)];
+                case 1:
+                    res = _a.sent();
+                    if (res instanceof request_error_1.RequestError) {
+                        throw res;
+                    }
+                    if (res.status === 201) {
+                        return [2 /*return*/, res.data];
+                    }
+                    return [2 /*return*/, undefined];
+            }
+        });
+    });
+}
+exports.postComment = postComment;
+function doRequest(octokit, prNumber, repoName, owner, body) {
+    return __awaiter(this, void 0, void 0, function () {
+        var request, res, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    request = "POST /repos/{owner}/{repo}/issues/{issue_number}/comments";
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, octokit.request(request, {
+                            owner: owner,
+                            repo: repoName,
+                            issue_number: prNumber,
+                            body: body
+                        })];
+                case 2:
+                    res = (_a.sent()).data;
+                    return [2 /*return*/, {
+                            data: res,
+                            status: 201,
                             url: request,
                             headers: {}
                         }];

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "typescript": "^4.8.3"
   },
   "engines": {
-    "node": "~16"
+    "node": ">=16"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { getLabels } from './getLabels'
 import { searchPRwithLabels } from './searchPRwithLabels'
 import { searchCodePR } from './searchCodePR'
 import { mergePR } from './mergePR'
+import { postComment } from './postComment'
 
 interface Input {
     prNumber: number
@@ -27,12 +28,21 @@ export async function main(octokit: Octokit, input: Input, merge: boolean): Prom
         const PRs = await searchPRwithLabels(octokit, repoName, owner, labelsToSearch)
         const otherPRs = PRs.filter((id) => id !== prNumber)
         core.info(`Found PRs: ${PRs}`)
+
+        const codePR = await searchCodePR(octokit, prNumber, repoName, owner)
+
         if (otherPRs.length > 0) {
-            core.info(`Other open PRs found for these labels: ${otherPRs}. Nothing to merge yet.`)
+            const actor = process.env.GITHUB_ACTOR
+            const message = `${actor ? `@${actor}: ` : ''}Other open PRs found for these labels: ${otherPRs}. Nothing to merge yet.`
+            core.info(message)
+            if (codePR) {
+                await postComment(octokit, codePR.number, codePR.base.repo.name, codePR.base.repo.owner.login, message)
+            } else {
+                core.warning(`Could not identify original code PR for ${repoName}#${prNumber}. Cannot post comment.`)
+            }
             return core.ExitCode.Success
         } else {
             core.info('No other open PRs found, proceeding to merge original code PR')
-            const codePR = await searchCodePR(octokit, prNumber, repoName, owner)
             if (!codePR) {
                 core.warning(`Could not identify original code PR for ${repoName}#${prNumber}. Verify title/body format.`)
                 return core.ExitCode.Success

--- a/src/postComment.ts
+++ b/src/postComment.ts
@@ -1,0 +1,45 @@
+import { Octokit } from "@octokit/core"
+import { RequestError } from "@octokit/request-error"
+import { Endpoints } from "@octokit/types"
+
+type postCommentResponse = Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"]
+
+export async function postComment(octokit: Octokit, prNumber: number, repoName: string, owner: string, body: string): Promise<postCommentResponse['data']> {
+
+    const res = await doRequest(octokit, prNumber, repoName, owner, body)
+
+    if (res instanceof RequestError) {
+        throw res
+    }
+
+    if (res.status === 201) {
+        return res.data
+    }
+
+    return undefined
+}
+
+async function doRequest(octokit: Octokit, prNumber: number, repoName: string, owner: string, body: string): Promise<postCommentResponse | RequestError>{
+
+    const request = "POST /repos/{owner}/{repo}/issues/{issue_number}/comments"
+
+    try {
+        const { data: res } = await octokit.request(request, {
+            owner: owner,
+            repo: repoName,
+            issue_number: prNumber,
+            body: body
+        })
+        return {
+            data: res,
+            status: 201,
+            url: request,
+            headers: {}
+        }
+    } catch (error) {
+        return new RequestError(error.message, error.status, {
+            request: error.request,
+            response: error.response,
+        })
+    }
+}


### PR DESCRIPTION
**Title:** feat: add PR comment on original code PR when other PRs are open

**Description:**

* **Summary:** Added functionality to post a comment in the original code Pull Request when there are other open PRs for the same environment/labels, instead of only logging it. Mention the user who merged the PR.
* **Motivation:** Improve visibility of the deployment status. Instead of having to check the logs of the action, the developer will be notified directly in the original code PR.
* **Changes:**
    * Created `src/postComment.ts` to handle GitHub PR comments.
    * Modified `src/main.ts` to find the original code PR and post a status comment when `otherPRs.length > 0`.
    * Included `GITHUB_ACTOR` mention in the posted comment.
    * Updated `README.md` with features and inputs.
    * Updated `dist/index.js` with the compiled changes.
* **Testing:**
    * Created unit tests in `__tests__/main.test.ts` to verify the comment posting logic and actor mention.
    * Verified with `npm run build` and `npm test`.
* **Considerations:**
    * It uses the `GITHUB_ACTOR` environment variable provided by GitHub Actions to identify the person who merged the PR in the destination repository.

**Review Checklist:**

1. **Code Review:** Focus on the new `postComment` module and its integration in `main.ts`.
2. **Manual Testing:** N/A (Verified via mocked unit tests).
3. **CI Testing:** CI tests are expected to pass with the new mocked tests.